### PR TITLE
Split RabbitMQ Publisher and Subscriber

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,3 @@ WORKDIR /app
 
 # Installing requirements
 RUN pip3.5 install -r /app/requirements.txt
-
-# Expose ports
-EXPOSE 8000
-
-CMD ["gunicorn", "-b", "0.0.0.0:8000", "pubsub.server:app"]

--- a/README.rst
+++ b/README.rst
@@ -23,10 +23,22 @@ Pulling and Starting RabbitMQ::
 
 You can access now RabbitMQ Management using http://localhost:15672 using credentials: guest/guest
 
-Pulling and Starting python-pubsub image::
+Pulling image::
 
 	docker pull csarcom/python-pubsub:latest
-	docker run -it -p 8000:8000 --link my_rabbitmq:my_rabbitmq -v /$(pwd):/app csarcom/python-pubsub
+
+Starting publisher::
+
+	docker run -d -p 8000:8000 --link my_rabbitmq:my_rabbitmq -v /$(pwd):/app csarcom/python-pubsub gunicorn -b 0.0.0.0:8000 pubsub.publisher:app
+
+Starting subscriber::
+
+	docker run -it --link my_rabbitmq:my_rabbitmq -v /$(pwd):/app csarcom/python-pubsub python pubsub/subscriber.py
+
+Cleanup containers::
+
+	docker stop $(docker ps -a -q)
+	docker rm $(docker ps -a -q)
 
 Docker Compose
 --------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,17 @@
-pubsub:
+publisher:
+    container_name: publisher
     image: csarcom/python-pubsub
+    command: gunicorn -b 0.0.0.0:8000 pubsub.publisher:app
     ports:
         - "8000:8000"
+    links:
+        - rabbitmq
+    volumes:
+        - ./:/app
+subscriber:
+    container_name: subscriber
+    image: csarcom/python-pubsub
+    command: python pubsub/subscriber.py
     links:
         - rabbitmq
     volumes:

--- a/pubsub/backend/base.py
+++ b/pubsub/backend/base.py
@@ -1,6 +1,14 @@
-class BaseBackend(object):
+class BasePublisher(object):
     def start(self):
         raise NotImplementedError
 
     def publish(self):
+        raise NotImplementedError
+
+
+class BaseSubscriber(object):
+    def start(self):
+        raise NotImplementedError
+
+    def on_message(self):
         raise NotImplementedError

--- a/pubsub/backend/rabbitmq.py
+++ b/pubsub/backend/rabbitmq.py
@@ -4,32 +4,16 @@ monkey.patch_all()
 import uuid
 
 import kombu
-import gevent
 
 from kombu.mixins import ConsumerMixin
 
-from pubsub.backend.base import BaseBackend
+from pubsub.backend.base import BaseSubscriber, BasePublisher
 from pubsub.helpers import get_config
 
 
-class RabbitMQ(BaseBackend):
-    def __init__(self, *args, **kwargs):
-        config = get_config('rabbitmq')
-        self.publisher = RabbitMQPublisher(config.get('publisher', None))
-        self.subscriber = RabbitMQSubscriber(config.get('subscriber', None))
-
-    def start(self):
-        self.publisher.start()
-        self.subscriber.start()
-        gevent.spawn(self.subscriber.run_forever)
-
-    def publish(self, message):
-        return self.publisher.publish(message)
-
-
-class RabbitMQPublisher(object):
-    def __init__(self, config):
-        self.config = config
+class RabbitMQPublisher(BasePublisher):
+    def __init__(self):
+        self.config = get_config('rabbitmq').get('publisher', None)
         self._connection = self._connect()
 
     def start(self):
@@ -61,9 +45,9 @@ class RabbitMQPublisher(object):
         return connection
 
 
-class RabbitMQSubscriber(ConsumerMixin):
-    def __init__(self, config=None):
-        self.config = config
+class RabbitMQSubscriber(ConsumerMixin, BaseSubscriber):
+    def __init__(self):
+        self.config = get_config('rabbitmq').get('subscriber', None)
         self.connection = self._connect()
 
     def start(self):

--- a/pubsub/publisher.py
+++ b/pubsub/publisher.py
@@ -4,7 +4,7 @@ import falcon
 
 from pubsub.middleware import JSONTranslator, RequireJSON
 from pubsub.resource import PublishResource
-from pubsub.backend.rabbitmq import RabbitMQ
+from pubsub.backend.rabbitmq import RabbitMQPublisher
 
 time.sleep(5)
 app = falcon.API(middleware=[
@@ -14,4 +14,4 @@ app = falcon.API(middleware=[
 
 # Routes
 
-app.add_route('/publish/', PublishResource(backend=RabbitMQ))
+app.add_route('/publish/', PublishResource(backend=RabbitMQPublisher))

--- a/pubsub/resource.py
+++ b/pubsub/resource.py
@@ -17,11 +17,11 @@ class ServerResource(object):
 
 class PublishResource(ServerResource):
     def __init__(self, backend, *args, **kwargs):
-        self.backend = backend()
-        self.backend.start()
+        self.publisher = backend()
+        self.publisher.start()
 
     def _dispatch(self, message):
-        return self.backend.publish(message)
+        return self.publisher.publish(message)
 
     @falcon.before(max_body(64 * 1024))
     def on_post(self, req, resp):
@@ -29,6 +29,7 @@ class PublishResource(ServerResource):
             message = req.context['payload']
         except KeyError:
             raise falcon.HTTPBadRequest(
+
                 'Missing payload',
                 'A payload must be submitted in the request body.')
 

--- a/pubsub/subscriber.py
+++ b/pubsub/subscriber.py
@@ -1,0 +1,12 @@
+import gevent
+import sys
+sys.path.insert(0, '.')
+
+from pubsub.backend.rabbitmq import RabbitMQSubscriber
+
+
+if __name__ == '__main__':
+    subscriber = RabbitMQSubscriber()
+    subscriber.start()
+    g = gevent.spawn(subscriber.run_forever)
+    g.join()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,29 @@
+import pytest
+
+from pubsub.backend.base import BasePublisher, BaseSubscriber
+
+
+class TestBasePublisher(object):
+    def setup_class(self):
+        self.publisher = BasePublisher()
+
+    def test_base_publisher_start(self):
+        with pytest.raises(NotImplementedError):
+            self.publisher.start()
+
+    def test_base_publisher_publish(self):
+        with pytest.raises(NotImplementedError):
+            self.publisher.publish()
+
+
+class TestBaseSubscriber(object):
+    def setup_class(self):
+        self.subscriber = BaseSubscriber()
+
+    def test_base_subscriber_start(self):
+        with pytest.raises(NotImplementedError):
+            self.subscriber.start()
+
+    def test_base_subscriber_on_message(self):
+        with pytest.raises(NotImplementedError):
+            self.subscriber.on_message()

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -32,6 +32,18 @@ class TestRabbitMQPublisher(object):
         self.publisher.publish(None)
         assert self.publisher._producer.publish.called
 
+    @mock.patch('kombu.Exchange')
+    def test_create_exchange(self, mocked_exchange):
+        self.publisher.config = {'exchange': {}}
+        exchange = self.publisher._create_exchange()
+        assert exchange is not None
+
+    @mock.patch('kombu.Connection')
+    def test_connect(self, mocked_connection):
+        self.publisher.config = {'connection': {}}
+        connection = self.publisher._connect()
+        assert connection is not None
+
 
 class TestRabbitMQSubscriber(object):
 
@@ -69,3 +81,26 @@ class TestRabbitMQSubscriber(object):
         consumers = self.subscriber.get_consumers(mock.Mock(), mock.Mock())
         assert type(consumers) is list
         assert len(consumers) == 1
+
+    @mock.patch('kombu.Exchange')
+    def test_create_exchange(self, mocked_exchange):
+        self.subscriber.config = {'exchange': {}}
+        exchange = self.subscriber._create_exchange()
+        assert exchange is not None
+
+    @mock.patch('kombu.Queue')
+    def test_create_queue(self, mocked_queue):
+        self.subscriber.config = {'queue': {}}
+        connection = self.subscriber._create_queue()
+        assert connection is not None
+
+    @mock.patch('kombu.Connection')
+    def test_connect(self, mocked_connection):
+        self.subscriber.config = {'connection': {}}
+        connection = self.subscriber._connect()
+        assert connection is not None
+
+    @mock.patch('pubsub.backend.rabbitmq.RabbitMQSubscriber.run')
+    def test_call_consumer_run(self, mocked_function):
+        self.subscriber.run_forever()
+        assert mocked_function.called

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -1,49 +1,18 @@
 import mock
-import pytest
 
 
-from pubsub.backend.rabbitmq import (
-    RabbitMQ, RabbitMQPublisher, RabbitMQSubscriber)
-
-
-class TestRabbitMQ(object):
-
-    @mock.patch('pubsub.backend.rabbitmq.RabbitMQPublisher._connect')
-    @mock.patch('pubsub.backend.rabbitmq.RabbitMQSubscriber._connect')
-    def setup_class(self, mock1, mock2):
-        self.backend = RabbitMQ()
-
-    @mock.patch('pubsub.backend.rabbitmq.RabbitMQPublisher.start')
-    def test_call_start_publisher(self, mocked_function):
-        self.backend.start()
-        assert mocked_function.called
-
-    @mock.patch('pubsub.backend.rabbitmq.RabbitMQSubscriber.start')
-    def test_call_start_subscriber(self, mocked_function):
-        self.backend.start()
-        assert mocked_function.called
-
-    @mock.patch('pubsub.backend.rabbitmq.RabbitMQPublisher.publish')
-    def test_call_publish(self, mocked_function):
-        self.backend.publish(None)
-        assert mocked_function.called
-
-    @mock.patch('pubsub.backend.rabbitmq.RabbitMQPublisher.publish')
-    def test_publisher_publish_args(self, mocked_function):
-        self.backend.publish('message')
-        mocked_function.assert_called_with('message')
+from pubsub.backend.rabbitmq import RabbitMQPublisher, RabbitMQSubscriber
 
 
 class TestRabbitMQPublisher(object):
 
     @mock.patch('pubsub.backend.rabbitmq.RabbitMQPublisher._connect')
     def setup_class(self, mock1):
-        config = mock.Mock()
-        self.publisher = RabbitMQPublisher(config=config)
+        self.publisher = RabbitMQPublisher()
 
     @mock.patch('pubsub.backend.rabbitmq.RabbitMQPublisher._connect')
     def test_call_connect(self, mocked_function):
-        RabbitMQPublisher(config=mock.Mock())
+        RabbitMQPublisher()
         assert mocked_function.called
 
     @mock.patch('pubsub.backend.rabbitmq.RabbitMQPublisher._create_exchange')
@@ -68,7 +37,7 @@ class TestRabbitMQSubscriber(object):
 
     @mock.patch('pubsub.backend.rabbitmq.RabbitMQSubscriber._connect')
     def setup_class(self, mock1):
-        self.subscriber = RabbitMQSubscriber(config=mock.Mock())
+        self.subscriber = RabbitMQSubscriber()
 
     @mock.patch('pubsub.backend.rabbitmq.RabbitMQSubscriber._connect')
     def test_call_connect(self, mocked_function):


### PR DESCRIPTION
We can now build and run a full environment using docker-compose.

It will run a rabbitmq, publisher, subscriber containers.
