### PR TITLE
Fix bug with date being write at influx

### DIFF
--- a/pubsub/backend/rabbitmq.py
+++ b/pubsub/backend/rabbitmq.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime
 
 from kombu.mixins import ConsumerMixin
 
@@ -40,7 +41,8 @@ class RabbitMQPublisher(BasePublisher, RabbitMQHandler):
             message, exchange=self._exchange, **self.config.get('publish'))
         logger.info('Message sent: {0}'.format(message))
 
-        self.monitor.write(1)
+        point = (datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f'"), 1)
+        self.monitor.write(point)
         return message_id
 
 
@@ -78,4 +80,6 @@ class RabbitMQSubscriber(ConsumerMixin, BaseSubscriber, RabbitMQHandler):
 
         logger.info('Message received: {0}'.format(body))
         message.ack()
-        self.monitor.write(1)
+
+        point = (datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f'"), 1)
+        self.monitor.write(point)

--- a/pubsub/monitoring/influx.py
+++ b/pubsub/monitoring/influx.py
@@ -1,5 +1,4 @@
 import socket
-import datetime
 
 from influxdb import InfluxDBClient
 
@@ -15,9 +14,10 @@ class InfluxDB(object):
         self.client = InfluxDBClient(**config.get('client'))
         self.name = name
 
-    def write(self, data, date=datetime.datetime.now().strftime(
-              "%Y-%m-%d %H:%M:%S.%f'")):
-        """Write to InfluxDB"""
+    def write(self, point):
+        """Write to InfluxDB
+        point is a tuple that contain (DATE, VALUE)
+        """
 
         host = "{0}-{1}".format(self.name, socket.gethostname())
         json_body = [{
@@ -25,10 +25,11 @@ class InfluxDB(object):
             "tags": {
                 "host": host,
             },
-            "time": date,
+            "time": point[0],
             "fields": {
-                "value": data
+                "value": point[1]
             }}]
 
-        logger.debug('Write on InfluxDB: {0}. value={1}'.format(host, data))
+        logger.debug('Write on InfluxDB: {0}. point: {1}'.format(
+            host, point))
         self.client.write_points(json_body)

--- a/tests/test_influxdb.py
+++ b/tests/test_influxdb.py
@@ -18,14 +18,14 @@ class TestInfluxDB(object):
     def test_write_parameters(self, mocked_function):
         client = InfluxDB(name='something', config={'client': {}})
         date = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f'")
-        client.write(1, date)
-        mocked_function.assert_called_with(1, date)
+        client.write((date, 1))
+        mocked_function.assert_called_with((date, 1))
 
     @mock.patch('pubsub.monitoring.influx.InfluxDBClient.write_points')
     def test_write_influx(self, mocked_function):
         client = InfluxDB(name='something', config={'client': {}})
         date = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f'")
-        client.write(1, date)
+        client.write(point=(date, 1))
         mocked_function.assert_called_with(
             [{
                 "measurement": 'something',


### PR DESCRIPTION
The date was always the same, because it was a default value of write() function, which is a wrong way to do that.
The function was changed to receive a point parameter, this point parameter must be (date, value).
